### PR TITLE
Fix asset loading, added Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: rust
+
+script:
+  - cargo build
+  - RUST_BACKTRACE=1 cargo test
+
+sudo: false
+
+cache: cargo
+
+os:
+  - linux
+#  - osx
+  
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+
+addons:
+   apt:
+     packages:
+       - libasound2-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
 glium_text = { git = "https://github.com/fschutt/glium_text" }
 image = "0.17.0"
 twox-hash = "1.1.0"
-zip = "0.3.1"
+toml = "0.4.6"
 cpal = { git = "https://github.com/fschutt/cpal" }
 lewton = { git = "https://github.com/RustAudio/lewton" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,7 @@ authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
 glium_text = { git = "https://github.com/fschutt/glium_text" }
 image = "0.17.0"
 twox-hash = "1.1.0"
-cpal = { git = "https://github.com/fschutt/cpal" }
-lewton = { git = "https://github.com/RustAudio/lewton" }
+rodio = "0.6.0"
 
 [dependencies.glium]
 git = "https://github.com/fschutt/glium-backport"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ludum-dare-40"
+name = "bbengine"
 version = "0.1.0"
 authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Felix Schütt <felix.schuett@maps4print.com>"]
 glium_text = { git = "https://github.com/fschutt/glium_text" }
 image = "0.17.0"
 twox-hash = "1.1.0"
+zip = "0.3.1"
 cpal = { git = "https://github.com/fschutt/cpal" }
 lewton = { git = "https://github.com/RustAudio/lewton" }
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## Installation
 
 ```
+sudo apt install libasound2-dev
+```
+
+```
 # Windows only, for getting freetype to work
 git clone https://github.com/PistonDevelopers/binaries 
 git clone https://github.com/LudumDare41-TeamRust/BlueboxEngine

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ludum Dare 40 - Stack Boxes
+# Bluebox Engine
 
 ## Installation
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -7,6 +7,7 @@ use FastHashMap;
 pub const FONT_BIG_SIZE: u32 = 48;
 pub const FONT_MEDIUM_SIZE: u32 = 18;
 pub const FONT_SMALL_SIZE: u32 = 14;
+pub const GAME_TITLE: &str = "Stack Boxes!";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct LevelId(pub u32);
@@ -14,101 +15,165 @@ pub struct LevelId(pub u32);
 #[derive(Debug, Default)]
 pub struct Level {
     pub font_data: FastHashMap<String, Vec<u8>>,
-    pub image_data: FastHashMap<String, Vec<u8>>,
+    pub image_data: FastHashMap<String, (Vec<u8>, Option<SourceTextureRegion>)>,
     pub sound_data: FastHashMap<String, Vec<u8>>,
 }
 
 pub(crate) fn load_level(level_id: LevelId) -> Result<Level, LevelLoadError> {
     
     use std::fs::{self, File};
-    use std::io::Read;
-    use zip::ZipArchive;
+    use std::io::{Cursor, Read};
 
     let current_exe_path = ::std::env::current_exe()?;
     let mut gamedata_path = current_exe_path.parent().ok_or(LevelLoadError::InvalidParentDirectory)?.to_path_buf();
     gamedata_path.push("gamedata");
-
-    let gamedata_folder = File::open(gamedata_path)?;
     
     if !gamedata_path.is_dir() {
         return Err(LevelLoadError::GameDataIsNotAFolder);
     }
 
-    let searched_zip_file = format!("level{}.zip", level_id.0);
-    let mut found_zip_file = None;
+    let searched_dir_name = format!("level{}", level_id.0);
+    let mut found_level_directory = None;
     for entry in ::std::fs::read_dir(gamedata_path.as_path())? {
-
         let entry = entry?;
         let file_name = entry.file_name().into_string().map_err(|_| LevelLoadError::FileNameEncodingError)?;
 
-        if file_name != searched_zip_file {
+        if file_name != searched_dir_name {
             continue;
         }
 
-        if entry.path().is_dir() {
+        if !entry.path().is_dir() {
             return Err(LevelLoadError::InvalidLevelToLoad(level_id));
         }
 
-        found_zip_file = Some((entry.path(), entry.path().metadata().and_then(|m| Ok(m.len())).unwrap_or(0)));
+        found_level_directory = Some(entry.path());
     }
 
-    if found_zip_file.is_none() {
-        // level.zip file not found
+    if found_level_directory.is_none() {
         return Err(LevelLoadError::InvalidLevelToLoad(level_id));
     }
+    let found_level_directory = found_level_directory.unwrap();
 
-    let found_zip_file = found_zip_file.unwrap();
-    let level_zip_file = File::open(found_zip_file.0)?;
+    let mut images_directory = None;
+    let mut sounds_directory = None;
+    let mut fonts_directory = None;
 
-    let mut level = Level::default();
-    Ok(())
+    for entry in ::std::fs::read_dir(found_level_directory)? {
+        let entry = entry?;
+        let file_name = entry.file_name().into_string().map_err(|_| LevelLoadError::FileNameEncodingError)?;
+        match file_name.as_ref() {
+            "images" => images_directory = Some(entry.path()),
+            "sounds" => sounds_directory = Some(entry.path()),
+            "fonts" => fonts_directory = Some(entry.path()),
+            _ => { },
+        }
+    }
+
+    macro_rules! load_directory {
+        ($hashmap:ident, $directory:ident) => ({
+            if let Some(dir) = $directory {
+                for entry in ::std::fs::read_dir(dir)? {
+                    let entry = entry?;
+                    if entry.path().is_dir() {
+                        continue;
+                    }
+                    let file_name = entry.file_name().into_string()
+                        .map_err(|_| LevelLoadError::FileNameEncodingError)?;
+                    let file_size = entry.metadata().and_then(|m| Ok(m.len())).unwrap_or(0);
+                    let mut data = Vec::with_capacity(file_size as usize);
+                    let mut file = File::open(entry.path())?;
+                    file.read_to_end(&mut data);
+                    $hashmap.insert(file_name, data);
+                }
+            }
+        })
+    }
+
+    // load /images directory
+    let mut images = FastHashMap::default();
+    if let Some(dir) = images_directory {
+        for entry in ::std::fs::read_dir(dir)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                continue;
+            }
+            let file_name = entry.file_name().into_string()
+                .map_err(|_| LevelLoadError::FileNameEncodingError)?;
+            let file_size = entry.metadata().and_then(|m| Ok(m.len())).unwrap_or(0);
+            let mut data = Vec::with_capacity(file_size as usize);
+            let mut file = File::open(entry.path())?;
+            file.read_to_end(&mut data);
+            images.insert(file_name, (data, None));
+        }
+    }
+
+    if let Some(images_directory) = images_directory {
+        let mut source_texture_regions_file_path = images_directory.clone();
+        source_texture_regions_file_path.push("pixel_regions.toml");
+        let source_texture_regions_file = File::open(source_texture_regions_file_path.as_path())?;
+        let source_texture_regions = load_source_texture_regions_toml(&mut source_texture_regions_file)?;
+        for (k, v) in source_texture_regions {
+            if let Some(image) = images.get_mut(&k) {
+                image.1 = Some(v);
+            }
+        }        
+    }
+
+    let mut sounds = FastHashMap::default();
+    load_directory!(sounds, sounds_directory);
+
+    let mut fonts = FastHashMap::default();
+    load_directory!(fonts, fonts_directory);
+
+    let level = Level {
+        font_data: fonts,
+        image_data: images,
+        sound_data: sounds,
+    };
+
+    Ok(level)
 }
 
-// start screen
-pub const START_SCREEN_BUTTON_00_ID: &str = "../assets/images/ui/PNG/yellow_button04.png";
-pub const START_SCREEN_BUTTON_00_TX_STR: SourceTextureRegion = SourceTextureRegion {
-    texture_id: TextureId { texture_id: START_SCREEN_BUTTON_00_ID },
-    region: SourcePixelRegion {
-        bottom_x: 0,
-        bottom_y: 0,
-        width: 190,
-        height: 49,
-    }
-};
+use std::fs::File;
 
-// hero texture
-pub const HERO_TEXTURE_ID: &str = "../assets/images/hero.png";
-/* todo: add source pixel regions*/
-pub const HERO_TX_NORMAL_STR: SourceTextureRegion = SourceTextureRegion {
-    texture_id: TextureId { texture_id: HERO_TEXTURE_ID },
-    region: SourcePixelRegion {
-        bottom_x: 0,
-        bottom_y: 64,
-        width: 16,
-        height: 16,
-    }
-};
+fn load_source_texture_regions_toml(texture_region_file: &mut File) 
+-> Result<FastHashMap<String, SourceTextureRegion>, LevelLoadError> 
+{
+    use std::io::Read;
+    use toml::Value;
 
-// crate texture
-pub const CRATE_TEXTURE_ID: &str = "../assets/images/crate.png";
-pub const CRATE_TEXTURE_TX_STR: SourceTextureRegion = SourceTextureRegion {
-    texture_id: TextureId { texture_id: CRATE_TEXTURE_ID },
-    region: SourcePixelRegion {
-        bottom_x: 0,
-        bottom_y: 0,
-        width: 32,
-        height: 32,
-    }
-};
+    let mut file_contents = String::new();
+    texture_region_file.read_to_string(&mut file_contents)?;
+    let toml = file_contents.parse::<Value>()?;
+    match toml {
+        Value::Table(table) => {
+            let texture_regions: Vec<(&String, &Value)> = table.iter().filter(|(k,v)| k.as_ref() == "textures").collect()?;
+            let mut source_texture_hash_map = FastHashMap::default();
 
-// background texture
-pub const BACKGROUND_3_TEXTURE_ID: &str = "../assets/images/background/3.png";
-pub const BACKGROUND_3_TEXTURE_TX_STR: SourceTextureRegion = SourceTextureRegion {
-    texture_id: TextureId { texture_id: BACKGROUND_3_TEXTURE_ID },
-    region: SourcePixelRegion {
-        bottom_x: 0,
-        bottom_y: 0,
-        width: 256,
-        height: 182,
+            for (texture_key, texture_description) in texture_regions {
+                let texture_description = texture_description.as_table().ok_or(LevelLoadError::InvalidToml)?;
+                
+                let texture_state = texture_description.get("state").ok_or(LevelLoadError::InvalidToml)?.as_str().unwrap_or("default".into());
+                let texture_bottom_x = texture_description.get("bottom_x").ok_or(LevelLoadError::InvalidToml)?.as_integer().unwrap_or(0) as u32;
+                let texture_bottom_y = texture_description.get("bottom_y").ok_or(LevelLoadError::InvalidToml)?.as_integer().unwrap_or(0) as u32;
+                let texture_width = texture_description.get("width").ok_or(LevelLoadError::InvalidToml)?.as_integer().unwrap_or(0) as u32;
+                let texture_height = texture_description.get("height").ok_or(LevelLoadError::InvalidToml)?.as_integer().unwrap_or(0) as u32;
+
+                source_texture_hash_map.insert(*texture_key, SourceTextureRegion {
+                    texture_id: TextureId { texture_id: format!("{}#{}", texture_key, texture_state) },
+                    region: SourcePixelRegion {
+                        bottom_x: texture_bottom_x,
+                        bottom_y: texture_bottom_y,
+                        width: texture_width,
+                        height: texture_height,
+                    }
+                });
+            }
+
+            Ok(source_texture_hash_map)
+        },
+        _ => {
+            Err(LevelLoadError::InvalidToml)
+        }
     }
-};
+}

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,37 +1,71 @@
 //! Constants for easier access to the assets
 
 use texture::{SourcePixelRegion, TextureId, SourceTextureRegion, TextureInstanceId};
-
-// fonts
+use errors::LevelLoadError;
+use FastHashMap;
 
 pub const FONT_BIG_SIZE: u32 = 48;
 pub const FONT_MEDIUM_SIZE: u32 = 18;
 pub const FONT_SMALL_SIZE: u32 = 14;
 
-pub const FONT_ID: &str = "FredokaOne-Regular";
-pub const FONT: &[u8] = include_bytes!("../assets/fonts/FredokaOne-Regular.ttf");
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct LevelId(pub u32);
 
-pub const GAME_TITLE: &str = "StackBoxes!";
+#[derive(Debug, Default)]
+pub struct Level {
+    pub font_data: FastHashMap<String, Vec<u8>>,
+    pub image_data: FastHashMap<String, Vec<u8>>,
+    pub sound_data: FastHashMap<String, Vec<u8>>,
+}
 
-// audio
+pub(crate) fn load_level(level_id: LevelId) -> Result<Level, LevelLoadError> {
+    
+    use std::fs::{self, File};
+    use std::io::Read;
+    use zip::ZipArchive;
 
-pub const TITLE_SCREEN_SONG_DATA: &[u8] = include_bytes!("../assets/sounds/music/title_screen.ogg");
-pub const AUDIO_MSG_PLAY_TITLE_SCREEN_SONG: &'static str = "../assets/sounds/music/title_screen.ogg";
+    let current_exe_path = ::std::env::current_exe()?;
+    let mut gamedata_path = current_exe_path.parent().ok_or(LevelLoadError::InvalidParentDirectory)?.to_path_buf();
+    gamedata_path.push("gamedata");
 
-pub const GAME_SONG_1_DATA: &[u8] = include_bytes!("../assets/sounds/music/level_1.ogg");
-// pub const GAME_SONG_2_DATA: &[u8] = include_bytes!("../assets/sounds/music/level_2.ogg");
-// pub const GAME_SONG_3_DATA: &[u8] = include_bytes!("../assets/sounds/music/level_3.ogg");
-pub const AUDIO_MSG_PLAY_GAME_SONG: &'static str = "../assets/sounds/music/level_1.ogg";
+    let gamedata_folder = File::open(gamedata_path)?;
+    
+    if !gamedata_path.is_dir() {
+        return Err(LevelLoadError::GameDataIsNotAFolder);
+    }
 
-pub const ENDING_SONG_1_DATA: &[u8] = include_bytes!("../assets/sounds/music/ending.ogg");
-pub const AUDIO_MSG_PLAY_ENDING_SONG: &'static str = "../assets/sounds/music/ending.ogg";
+    let searched_zip_file = format!("level{}.zip", level_id.0);
+    let mut found_zip_file = None;
+    for entry in ::std::fs::read_dir(gamedata_path.as_path())? {
 
+        let entry = entry?;
+        let file_name = entry.file_name().into_string().map_err(|_| LevelLoadError::FileNameEncodingError)?;
 
-// -- textures
+        if file_name != searched_zip_file {
+            continue;
+        }
+
+        if entry.path().is_dir() {
+            return Err(LevelLoadError::InvalidLevelToLoad(level_id));
+        }
+
+        found_zip_file = Some((entry.path(), entry.path().metadata().and_then(|m| Ok(m.len())).unwrap_or(0)));
+    }
+
+    if found_zip_file.is_none() {
+        // level.zip file not found
+        return Err(LevelLoadError::InvalidLevelToLoad(level_id));
+    }
+
+    let found_zip_file = found_zip_file.unwrap();
+    let level_zip_file = File::open(found_zip_file.0)?;
+
+    let mut level = Level::default();
+    Ok(())
+}
 
 // start screen
 pub const START_SCREEN_BUTTON_00_ID: &str = "../assets/images/ui/PNG/yellow_button04.png";
-pub const START_SCREEN_BUTTON_00: &[u8] = include_bytes!("../assets/images/ui/PNG/yellow_button04.png");
 pub const START_SCREEN_BUTTON_00_TX_STR: SourceTextureRegion = SourceTextureRegion {
     texture_id: TextureId { texture_id: START_SCREEN_BUTTON_00_ID },
     region: SourcePixelRegion {
@@ -44,7 +78,6 @@ pub const START_SCREEN_BUTTON_00_TX_STR: SourceTextureRegion = SourceTextureRegi
 
 // hero texture
 pub const HERO_TEXTURE_ID: &str = "../assets/images/hero.png";
-pub const HERO_TEXTURE: &[u8] = include_bytes!("../assets/images/hero.png");
 /* todo: add source pixel regions*/
 pub const HERO_TX_NORMAL_STR: SourceTextureRegion = SourceTextureRegion {
     texture_id: TextureId { texture_id: HERO_TEXTURE_ID },
@@ -58,7 +91,6 @@ pub const HERO_TX_NORMAL_STR: SourceTextureRegion = SourceTextureRegion {
 
 // crate texture
 pub const CRATE_TEXTURE_ID: &str = "../assets/images/crate.png";
-pub const CRATE_TEXTURE_DATA: &[u8] = include_bytes!("../assets/images/crate.png");
 pub const CRATE_TEXTURE_TX_STR: SourceTextureRegion = SourceTextureRegion {
     texture_id: TextureId { texture_id: CRATE_TEXTURE_ID },
     region: SourcePixelRegion {
@@ -71,7 +103,6 @@ pub const CRATE_TEXTURE_TX_STR: SourceTextureRegion = SourceTextureRegion {
 
 // background texture
 pub const BACKGROUND_3_TEXTURE_ID: &str = "../assets/images/background/3.png";
-pub const BACKGROUND_3_TEXTURE_DATA: &[u8] = include_bytes!("../assets/images/background/3.png");
 pub const BACKGROUND_3_TEXTURE_TX_STR: SourceTextureRegion = SourceTextureRegion {
     texture_id: TextureId { texture_id: BACKGROUND_3_TEXTURE_ID },
     region: SourcePixelRegion {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -148,7 +148,7 @@ fn load_source_texture_regions_toml(texture_region_file: &mut File)
     let toml = file_contents.parse::<Value>()?;
     match toml {
         Value::Table(table) => {
-            let texture_regions: Vec<(&String, &Value)> = table.iter().filter(|(k,v)| *k == "textures").collect();
+            let texture_regions: Vec<(&String, &Value)> = table.iter().filter(|&(k,_)| *k == "textures").collect();
             let mut source_texture_hash_map = FastHashMap::default();
 
             for (texture_key, texture_description) in texture_regions {

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -1,6 +1,6 @@
 //! Constants for easier access to the assets
 
-use texture::{SourcePixelRegion, TextureId, SourceTextureRegion, TextureInstanceId};
+use texture::{SourcePixelRegion, TextureId, SourceTextureRegion};
 use errors::LevelLoadError;
 use FastHashMap;
 
@@ -21,8 +21,8 @@ pub struct Level {
 
 pub(crate) fn load_level(level_id: LevelId) -> Result<Level, LevelLoadError> {
     
-    use std::fs::{self, File};
-    use std::io::{Cursor, Read};
+    use std::fs::File;
+    use std::io::Read;
 
     let current_exe_path = ::std::env::current_exe()?;
     let mut gamedata_path = current_exe_path.parent().ok_or(LevelLoadError::InvalidParentDirectory)?.to_path_buf();

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,135 +1,156 @@
-//! The AudioContext is a channeled receiver than runs on a different thread.
-//!
-//! This makes the music independent from the game loop
+//! Rodio-based audio system
 
-use std::thread;
-use std::sync::mpsc;
-use cpal;
-use lewton::inside_ogg::OggStreamReader;
+use rodio::{default_endpoint, Endpoint, Sink};
+use std::{thread, sync::mpsc};
 
+/// Core audio context, maintains a handle to the background audio thread
 pub struct AudioContext {
-    sender: mpsc::Sender<&'static str>,
+    sender: mpsc::Sender<AudioMsg>,
     thread_handle: thread::JoinHandle<()>,
+}
+
+/// An audio message 
+pub struct AudioMsg {
+    /// Which song to affect. Usually this is the file name, e.g. "hiteffect1.ogg"
+    pub song: String,
+    /// Which speaker to play the sound on
+    /// TODO: does nothing yet
+    pub speaker: Speaker,
+    /// What to do with the song?
+    pub action: AudioAction,
+}
+
+/// Which speaker to play the sound on
+pub enum Speaker {
+    /// Audio will be played on both speakers with the same volume
+    Mono,
+    /// Spatial audio
+    Stereo { left: f32, right: f32 },
+}
+
+pub enum AudioAction {
+    /// Start a given song. Does nothing if the song is already playing. 
+    /// do_loop controls if the song is looped.
+    /// song is the actual song data, loaded from the file.
+    Start { song_data: Vec<u8>, do_loop: bool }, 
+    /// From 0.0 to 100.0 - adjusts the volume of the given song
+    AdjustVolume(f32),
+    /// Pauses the song. 
+    Pause,
+    /// Returns to playing the song, if previously paused
+    Play,
+    /// Fades out the song, with the value in milliseconds how long to fade out
+    /// TODO: does nothing yet
+    FadeOut(u32),
+    /// Plays the current song until it ends, with an optional fadeout effect in milliseconds
+    /// TODO: does nothing yet
+    PlayUntilEnd { fade_out: Option<u32> },
+}
+
+/// Error marker that the audio data isn't yet loaded and needs to be loaded 
+/// from the games main audio hashmap
+#[derive(Debug, Copy, Clone)]
+pub struct AudioDataNotLoaded;
+
+/// audio.rs internal audio cache, for caching multiple rodio::Sinks and 
+/// controlling the decoding of 
+struct AudioCache {
+    pub endpoint: Endpoint,
+    pub active_songs: FastHashMap<String, AudioSink>,
+}
+
+struct AudioSink {
+    /// The rodio::Sing
+    sink: Sink,
+    /// 1.0 = default volume
+    volume: f32,
+}
+
+impl AudioCache {
+
+    /// Creates a new audio cache
+    pub fn new() -> Self {
+        AudioCache {
+            endpoint: default_endpoint().unwrap(),
+            active_songs: FastHashMap::default(),
+        }
+    }
+
+    /// Updates or inserts a new song, based on the audio message
+    pub fn upsert(&mut self, msg: AudioMsg) -> Result<(), AudioDataNotLoaded> {
+        
+        match self.active_songs.entry(&msg.song) {
+            Occupied(o) => {
+                match msg.action {
+                    Start { .. } => { },
+                    AdjustVolume(vol) => {
+                        let vol = msg.volume / 100.0;
+                        if o.volume != vol {
+                            o.sink.set_volume(vol);
+                        }
+                    },
+                    Pause => {
+                        o.sink.pause();
+                    },
+                    Play => {
+                        o.sink.play();
+                    },
+                    _ => {
+                        #[cfg(debug_assertions)]
+                        { println!("unimplemented audio message!"); }
+                    }
+                }
+            },
+            Vacant(v) => {
+                match msg.action {
+                    Start { data, do_loop } => {
+                        // insert a new song
+                        let sink = Sink::new(&self.endpoint);
+                        let decoder = Decoder::new(Cursor::new(data)).unwrap();
+                        sink.append(decoder);
+                        v.insert(sink);
+                    },
+                    _ => {
+                        return Err(AudioDataNotLoaded);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl AudioContext {
 
     /// Starts a thread, returns the context
     pub fn new() -> Self {
-
         let (tx, rx) = mpsc::channel();
-
-        let thread_handle = thread::spawn(move || Self::async_music_loop(rx));
-
+        let thread_handle = thread::spawn(move || Self::music_loop(rx));
         Self {
             sender: tx,
             thread_handle: thread_handle,
         }
     }
 
-    pub fn send_msg(&self, msg: &'static str) -> Result<(), mpsc::SendError<&'static str>> {
+    pub fn send_msg(&self, msg: AudioMsg) -> Result<(), mpsc::SendError<&'static str>> {
         self.sender.send(msg)
     }
 
-    fn async_music_loop(rx: mpsc::Receiver<&'static str>) {
-
-        use cpal::{UnknownTypeBuffer, Sample};
-        use std::thread;
-        use std::sync::Arc;
-        use std::time::{Instant, Duration};
-
-        let songs = [::assets::TITLE_SCREEN_SONG_DATA, ::assets::GAME_SONG_1_DATA, ::assets::ENDING_SONG_1_DATA];
-        
-        // decode all the songs
-        let decoded_songs = songs.into_iter().enumerate().map(|(song_id, song_data)| {
-            let time_start = Instant::now();
-            let current_song = Song::decode_from_bytes(song_data);
-            let duration_decoding = (Instant::now() - time_start).subsec_nanos() as f32 / 1_000_000.0;
-            println!("decoded song {:?} in {:?} ms", song_id, duration_decoding);
-            Arc::new(current_song)
-        }).collect::<Vec<Arc<Song>>>();
-
-        let title_screen_song = &decoded_songs[0];
-        let game_song_1 = &decoded_songs[1];
-        let ending_screen_song = &decoded_songs[2];
-
-        let mut last_song_tx: Option<mpsc::Sender<()>> = None;
-        let mut last_song_id = "";
-
+    // music loop that runs on a background thread
+    fn music_loop(rx: mpsc::Receiver<&'static str>) {
+        let mut audio_cache = AudioCache::new();
         while let Ok(event) = rx.recv() {
-
-            if event == last_song_id { continue; }
-            let mut current_song = title_screen_song.clone();
-
-            match event {
-                ::assets::AUDIO_MSG_PLAY_TITLE_SCREEN_SONG => { current_song = title_screen_song.clone(); },
-                ::assets::AUDIO_MSG_PLAY_GAME_SONG => { current_song = game_song_1.clone(); },
-                ::assets::AUDIO_MSG_PLAY_ENDING_SONG => { current_song = ending_screen_song.clone(); },
-                _ => { println!("received garbage on audio thread: {:?}", event); }
-            }
-
-            let csong = current_song.clone();
-            let (new_tx, new_rx) = mpsc::channel();
-
-            thread::spawn(move || {
-
-                let endpoint = cpal::default_endpoint().unwrap();
-                let event_loop = cpal::EventLoop::new();
-
-                let mut iter = (&*csong).decoded.iter().cycle();
-
-                let supported_formats_range = endpoint.supported_formats().unwrap().next().unwrap();
-                let mut format = supported_formats_range.with_max_samples_rate();
-                format.samples_rate = cpal::SamplesRate(current_song.sample_rate);
-                let voice_id = event_loop.build_voice(&endpoint, &format).unwrap();
-                event_loop.play(voice_id);
-
-                // event loop blocks
-                event_loop.run(move |_voice_id, mut buffer| {
-
-                    // can only be i16
-                    if let UnknownTypeBuffer::I16(ref mut buffer) = buffer {
-                        'outer: for (idx, d) in buffer.iter_mut().enumerate() {
-                            *d = iter.next().map(|s| s.to_i16()).unwrap_or(0_i16);
-                        }
-                    }
-
-                    if let Err(mpsc::TryRecvError::Disconnected) = new_rx.try_recv() {
-                        return None;
-                    }
-
-                    Some(())
-                });
-
-            });
-
-            // save the transmitting end in order to kill the song when we start a new song
-            last_song_id = event;
-            last_song_tx = Some(new_tx);
+            audio_cache.upsert(event).unwrap_or_else(|e| {
+                #[cfg(debug_assertions)]
+                { println!("error upserting song: {:?}!", e); }
+            })
         }
     }
 }
 
-pub struct Song {
-    pub decoded: Vec<i16>,
-    pub sample_rate: u32,
-}
-
-impl Song {
-
-    /// DO NOT TOUCH THIS DECODING FUNCTION IT IS MAGIC
-    pub fn decode_from_bytes(data: &[u8]) -> Self {
-        let mut srr = OggStreamReader::new(::std::io::Cursor::new(data)).unwrap();
-        let sample_rate = srr.ident_hdr.audio_channels as f32 * srr.ident_hdr.audio_sample_rate as f32;
-
-        let mut decoded = Vec::<i16>::new();
-        while let Ok(Some(mut pck_samples)) = srr.read_dec_packet_itl() {
-            decoded.append(&mut pck_samples);
-        }
-
-        Self {
-            decoded: decoded,
-            sample_rate: sample_rate as u32,
-        }
+impl Drop for AudioContext {
+    fn drop(&mut self) {
+        self.thread_handle.join().unwrap();
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -74,13 +74,13 @@ impl OpenGlContext {
     }
 
     // load a font
-    pub fn add_font<R>(&mut self, id: &'static str, size: u32, source: R)
+    pub fn add_font<R>(&mut self, id: String, size: u32, source: R)
         -> FontInstanceId where R: Read
     {
         self.font_system.add_font(id, size, source, &self.display)
     }
 
-    pub fn add_texture_png<R>(&mut self, id: &'static str, source: R)
+    pub fn add_texture_png<R>(&mut self, id: String, source: R)
         -> TextureId
         where R: BufRead + Seek
     {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,5 @@
-use glium::{self, Display, Frame, IndexBuffer, PolygonMode, Program, VertexBuffer};
-use glium::backend::Facade;
+use glium;
 use glium::index::{NoIndices, PrimitiveType};
-use glium::texture::CompressedSrgbTexture2d;
-use glium_text::{TextSystem, FontTexture};
-
 use std::io::{BufRead, Seek, Read};
 
 use errors::Error as AppError;
@@ -43,10 +39,8 @@ impl OpenGlContext {
         height: u32,
     ) -> Result<Self, AppError>
     {
-        use glium::DisplayBuild;
-        use glium::glutin::{WindowBuilder, GlRequest};
-        use glium::debug::DebugCallbackBehavior;
-        use glium::Surface;
+        use glium::{Program, DisplayBuild};
+        use glium::glutin::GlRequest;
         use glium::glutin;
 
         let display = glutin::WindowBuilder::new()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,21 @@
+use assets::LevelId;
+
 #[derive(Debug, Copy, Clone)]
 pub struct Error {
 
+}
+
+#[derive(Debug)]
+pub enum LevelLoadError {
+    Io(::std::io::Error),
+    GameDataIsNotAFolder,
+    InvalidLevelToLoad(LevelId),
+    FileNameEncodingError,
+    InvalidParentDirectory,
+}
+
+impl From<::std::io::Error> for LevelLoadError {
+    fn from(e: ::std::io::Error) -> Self {
+        LevelLoadError::Io(e)
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,10 +12,18 @@ pub enum LevelLoadError {
     InvalidLevelToLoad(LevelId),
     FileNameEncodingError,
     InvalidParentDirectory,
+    InvalidToml,
+    TomlParseError(::toml::de::Error),
 }
 
 impl From<::std::io::Error> for LevelLoadError {
     fn from(e: ::std::io::Error) -> Self {
         LevelLoadError::Io(e)
+    }
+}
+
+impl From<::toml::de::Error> for LevelLoadError {
+    fn from(e: ::toml::de::Error) -> Self {
+        LevelLoadError::TomlParseError(e)
     }
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,6 +1,6 @@
 //! Font data that needs to be rendered
 
-use glium_text::{self, TextSystem, FontTexture, TextDisplay};
+use glium_text::{self, TextSystem, FontTexture};
 use glium::backend::Facade;
 use glium::Frame;
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -9,9 +9,9 @@ use std::io::Read;
 use color::Color;
 use FastHashMap;
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct FontInstanceId {
-    pub font_name: &'static str,
+    pub font_name: String,
     pub font_size: u32,
 }
 
@@ -31,7 +31,7 @@ impl FontSystem {
         }
     }
 
-    pub fn add_font<R, F>(&mut self, id: &'static str, size: u32, source: R, display: &F)
+    pub fn add_font<R, F>(&mut self, id: String, size: u32, source: R, display: &F)
         -> FontInstanceId where R: Read, F: Facade
     {
         let id = FontInstanceId {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,5 +1,4 @@
-use glium::{Program, Frame};
-use audio::AudioContext;
+use glium::Frame;
 use {TextureInstanceIdMap, FontInstanceIdMap};
 use color::Color;
 use font::FontInstanceId;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -35,12 +35,12 @@ impl<'a> GameFrame<'a> {
     // notice: panics if the font isn't valid!!!
     pub fn get_font(&self, id: &'static str) -> FontInstanceId {
         let font_id = self.font_ids.get(id);
-        *font_id.unwrap()
+        font_id.unwrap().clone()
     }
 
     pub fn get_texture(&self, id: &'static str) -> TextureId {
         let texture_id = self.texture_ids.get(id);
-        *texture_id.unwrap()
+        texture_id.unwrap().clone()
     }
 
     pub fn calculate_font_width(&self, id: &FontInstanceId, text: &str) -> f32 {

--- a/src/game.rs
+++ b/src/game.rs
@@ -132,10 +132,10 @@ impl Game {
         // -- initialize textures
         let mut available_texture_ids = TextureInstanceIdMap::default();
         let mut texture_regions = SourceTextureRegionMap::default();
-        for (texture_id, (texture_data, opt_texture_region)) in &assets.image_data {
+        for (texture_id, &(ref texture_data, ref opt_texture_region)) in &assets.image_data {
             let texture_start_game = renderer.context.add_texture_png(texture_id.clone(), Cursor::new(texture_data));
             available_texture_ids.insert(texture_id.clone(), texture_start_game);
-            if let Some(opt_texture_region) = opt_texture_region {
+            if let Some(ref opt_texture_region) = *opt_texture_region {
                 texture_regions.insert(opt_texture_region.texture_id.texture_id.clone(), opt_texture_region.clone());
             } 
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,5 @@
 //! Input handling module, handles incoming events for the window
 
-use glium;
 use glium::glutin::{Event, MouseCursor, ElementState,VirtualKeyCode, MouseButton};
 
 use std::time::{Duration, Instant};

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,8 @@
 #![cfg_attr(feature = "clippy", warn(unseparated_literal_suffix))]
 #![cfg_attr(feature = "clippy", warn(wrong_pub_self_convention))]
 
+#![deny(unused_must_use)]
+
 #[macro_use] extern crate glium;
 extern crate image;
 extern crate glium_text;
@@ -47,8 +49,9 @@ pub mod actions;
 
 pub type FastHashMap<T, U> = ::std::collections::HashMap<T, U, ::std::hash::BuildHasherDefault<::twox_hash::XxHash>>;
 pub type FontInstanceIdMap = FastHashMap<&'static str, font::FontInstanceId>;
-pub type TextureInstanceIdMap = FastHashMap<&'static str, texture::TextureId>;
+pub type TextureInstanceIdMap = FastHashMap<String, texture::TextureId>;
 pub type ShaderHashMap = FastHashMap<&'static str, ::glium::Program>;
+pub type SourceTextureRegionMap = FastHashMap<String, ::texture::SourceTextureRegion>;
 
 fn main() {
     let mut game = game::Game::new(800, 600);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,6 @@
 
 #![windows_subsystem = "windows"]
 
-#![allow(dead_code)]
-#![allow(unused_imports)]
-#![allow(unused_macros)]
-#![allow(unused_doc_comment)]
-#![allow(unused_variables)]
-#![allow(unused_assignments)]
-
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![warn(trivial_numeric_casts,
@@ -31,8 +24,7 @@
 extern crate image;
 extern crate glium_text;
 extern crate twox_hash;
-extern crate cpal;
-extern crate lewton;
+extern crate rodio;
 
 pub mod input;
 pub mod renderer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,9 @@
 extern crate image;
 extern crate glium_text;
 extern crate twox_hash;
+extern crate toml;
 extern crate cpal;
 extern crate lewton;
-extern crate zip;
 
 pub mod input;
 pub mod renderer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ extern crate glium_text;
 extern crate twox_hash;
 extern crate cpal;
 extern crate lewton;
+extern crate zip;
 
 pub mod input;
 pub mod renderer;

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -3,8 +3,7 @@
 //! Calculates the physics for the game world, returns a description of the world
 //! in world coordinates
 
-use player_state::{PlayerSpritePosition, PlayerState};
-use input::GameInputEvent;
+use player_state::PlayerSpritePosition;
 use std::time::Instant;
 
 /// If the player presses a key, he should arrive at his goal (with linear interpolation)

--- a/src/player_state.rs
+++ b/src/player_state.rs
@@ -1,5 +1,5 @@
 use camera::Camera;
-use physics::{PhysicsWorld, PhysicsFinalizedData, PlayerResult, MAX_SPEED, CratePosition};
+use physics::{PhysicsWorld, PhysicsFinalizedData, PlayerResult, CratePosition};
 use input::GameInputEvent;
 use std::time::{Duration, Instant};
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -3,8 +3,7 @@ use std::io::{BufRead, Seek};
 use glium::texture::CompressedSrgbTexture2d;
 use glium::backend::{Context, Facade};
 use glium::texture::RawImage2d;
-use glium::{DrawParameters, VertexBuffer, Program, Frame};
-use ui::UiRect;
+use glium::{DrawParameters, VertexBuffer, Frame};
 use std::rc::Rc;
 use ShaderHashMap;
 use std::cell::Cell;
@@ -107,8 +106,6 @@ impl TextureSystem {
                         shaders: &ShaderHashMap, draw_options: TextureDrawOptions)
     {
         use glium::{Surface, Blend, Depth};
-        use glium::draw_parameters::DepthTest;
-        use glium::draw_parameters::DepthClamp;
 
         let shader = shaders.get(::context::PIXEL_TO_SCREEN_SHADER_ID).unwrap();
         let texture = self.textures.get(&texture_id.source_texture_region.texture_id).unwrap();

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -85,7 +85,7 @@ impl TextureSystem {
         Self::default()
     }
 
-    pub fn add_png_texture<R, F>(&mut self, id: &'static str, source: R, display: &F)
+    pub fn add_png_texture<R, F>(&mut self, id: String, source: R, display: &F)
         -> TextureId
         where R: BufRead + Seek, F: Facade
     {
@@ -95,7 +95,7 @@ impl TextureSystem {
         let image = RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
         let opengl_texture = CompressedSrgbTexture2d::new(display, image).unwrap();
 
-        let id = TextureId { texture_id: id.to_string() };
+        let id = TextureId { texture_id: id };
         self.textures.insert(id.clone(), opengl_texture);
         id
     }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -9,9 +9,9 @@ use std::rc::Rc;
 use ShaderHashMap;
 use std::cell::Cell;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TextureId {
-    pub texture_id: &'static str,
+    pub texture_id: String,
 }
 
 pub struct TextureSystem {
@@ -47,7 +47,7 @@ pub struct TargetPixelRegion {
     pub screen_height: u32,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceTextureRegion {
     /// Texture ID for looking it up in the TextureSystem at runtime
     pub texture_id: TextureId,
@@ -55,7 +55,7 @@ pub struct SourceTextureRegion {
     pub region: SourcePixelRegion,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TextureInstanceId {
     pub source_texture_region: SourceTextureRegion,
     pub target_texture_region: TargetPixelRegion,
@@ -96,7 +96,7 @@ impl TextureSystem {
         let image = RawImage2d::from_raw_rgba_reversed(&image.into_raw(), image_dimensions);
         let opengl_texture = CompressedSrgbTexture2d::new(display, image).unwrap();
 
-        let id = TextureId { texture_id: id };
+        let id = TextureId { texture_id: id.to_string() };
         self.textures.insert(id.clone(), opengl_texture);
         id
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,8 @@
 //! UI rendering with rectangles - either has a solid color or an image attached
 use color::Color;
 use game::GameState;
-use glium::texture::CompressedSrgbTexture2d;
 use font::FontInstanceId;
 use input::WindowState;
-use std::rc::Rc;
-use std::cell::RefCell;
 use texture::TextureInstanceId;
 
 #[derive(Clone)]


### PR DESCRIPTION
Previously, the asset loading relied on including images and fonts inside the binary

Now, you have to adhere to a certain layout for the game to run:

```yaml
- game.exe
- gamedata
    - level1
        - images
            - image1.png
            - pixel_regions.toml
        - sounds
            - level1.ogg
        - fonts
            - Roboto.ttf
```

The file name is here used as the key, i.e. "image1.png". Since we only load one level at a time, this won't create conflicts. 

`pixel_regions.toml` is a special file that has entries like this:

```toml
# hero character, running state
[textures."hero.png"]
state       = "running"
bottom_x    = 0
bottom_y    = 64
width       = 16
height      = 16

# crate texture
[textures."crate.png"]
state       = "default"
bottom_x    = 0
bottom_y    = 0
width       = 32
height      = 32
```

This way, artist can put multiple states of a character on one sprite texture. For example the character can have run, jump, etc. states, but all on one character sprite.